### PR TITLE
Edited eol from lf to auto to stop errors from occuring

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,12 @@ module.exports = {
   },
   plugins: ['prettier'],
   rules: {
-    'prettier/prettier': 'error',
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
     'func-names': 'off',
     'no-console': 'off',
     'prefer-arrow-callback': 'warn',

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,7 +2,7 @@
   "arrowParens": "always",
   "bracketSpacing": true,
   "embeddedLanguageFormatting": "auto",
-  "endOfLine": "lf",
+  "endOfLine": "auto",
   "htmlWhitespaceSensitivity": "css",
   "insertPragma": false,
   "jsxSingleQuote": false,


### PR DESCRIPTION
Changed eol on prettier and eslint from "lf" to "auto" to stop errors from occurring when running on Windows devices.